### PR TITLE
Make `parse` function agnostic

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -27,7 +27,6 @@ import type { JSONQuery, JSONQueryParseOptions, OperatorGroup } from './types'
  */
 export function parse(query: string, options?: JSONQueryParseOptions): JSONQuery {
   const customOperators = options?.operators ?? []
-  const allFunctions = { ...functions, ...options?.functions }
   const allOperators = extendOperators(operators, customOperators)
   const allOperatorsMap = Object.assign({}, ...allOperators)
   const allVarargOperators = varargOperators.concat(
@@ -134,10 +133,6 @@ export function parse(query: string, options?: JSONQueryParseOptions): JSONQuery
       return parseObject()
     }
     i++
-
-    if (!allFunctions[name]) {
-      throwError(`Unknown function '${name}'`)
-    }
 
     skipWhitespace()
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,4 +1,3 @@
-import { functions } from './functions'
 import { extendOperators, leftAssociativeOperators, operators, varargOperators } from './operators'
 import {
   startsWithIntRegex,

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,6 @@ export interface JSONQueryStringifyOptions {
 }
 
 export interface JSONQueryParseOptions {
-  functions?: Record<string, boolean> | FunctionBuildersMap
   operators?: CustomOperator[]
 }
 

--- a/test-suite/parse.test.json
+++ b/test-suite/parse.test.json
@@ -89,11 +89,6 @@
     },
     {
       "category": "function",
-      "description": "should throw an error in case of an unknown function name",
-      "tests": [{ "input": "foo(42)", "throws": "Unknown function 'foo' (pos: 4)" }]
-    },
-    {
-      "category": "function",
       "description": "should throw an error when the end bracket is missing",
       "tests": [{ "input": "sort(.age, \"desc\"", "throws": "Character ')' expected (pos: 17)" }]
     },


### PR DESCRIPTION
Fixes #11 by making `parse` unaware of the list with available functions, instead it just parses functions based on the syntax `name(arg1, arg2, ...)`.