### PR TITLE
feat: add test cases for handling empty arrays and non-array input in functions

### DIFF
--- a/src/compile.test.ts
+++ b/src/compile.test.ts
@@ -108,28 +108,6 @@ describe('error handling', () => {
       { data: null, query: ['sum'] }
     ])
   })
-
-  test('should do nothing when sorting objects without a getter', () => {
-    const data = [{ a: 1 }, { c: 3 }, { b: 2 }]
-    expect(go(data, ['sort'])).toEqual(data)
-  })
-
-  test('should not crash when sorting a list with nested arrays', () => {
-    expect(go([[3], [7], [4]], ['sort'])).toEqual([[3], [4], [7]])
-    expect(go([[], [], []], ['sort'])).toEqual([[], [], []])
-  })
-
-  test('should throw an error when calculating the sum of an empty array', () => {
-    expect(() => go([], ['sum'])).toThrow('Reduce of empty array with no initial value')
-  })
-
-  test('should throw an error when calculating the prod of an empty array', () => {
-    expect(() => go([], ['prod'])).toThrow('Reduce of empty array with no initial value')
-  })
-
-  test('should throw an error when calculating the average of an empty array', () => {
-    expect(() => go([], ['average'])).toThrow('Reduce of empty array with no initial value')
-  })
 })
 
 describe('customization', () => {

--- a/src/compile.test.ts
+++ b/src/compile.test.ts
@@ -97,7 +97,7 @@ describe('error handling', () => {
       actualErr = err
     }
 
-    expect(actualErr?.message).toBe("Cannot read properties of null (reading 'reduce')")
+    expect(actualErr?.message).toBe('Array expected')
     expect(actualErr?.jsonquery).toEqual([
       { data: scoreData, query },
       {
@@ -117,18 +117,6 @@ describe('error handling', () => {
   test('should not crash when sorting a list with nested arrays', () => {
     expect(go([[3], [7], [4]], ['sort'])).toEqual([[3], [4], [7]])
     expect(go([[], [], []], ['sort'])).toEqual([[], [], []])
-  })
-
-  test('should throw an error when calculating the sum of an empty array', () => {
-    expect(() => go([], ['sum'])).toThrow('Reduce of empty array with no initial value')
-  })
-
-  test('should throw an error when calculating the prod of an empty array', () => {
-    expect(() => go([], ['prod'])).toThrow('Reduce of empty array with no initial value')
-  })
-
-  test('should throw an error when calculating the average of an empty array', () => {
-    expect(() => go([], ['average'])).toThrow('Reduce of empty array with no initial value')
   })
 })
 

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1,4 +1,4 @@
-import { functions } from './functions'
+import { functions, throwTypeError } from './functions'
 import { isArray, isObject } from './is'
 import type {
   Fun,
@@ -47,8 +47,4 @@ function compileFunction(query: JSONQueryFunction, functions: FunctionBuildersMa
   }
 
   return fnBuilder(...args)
-}
-
-function throwTypeError(message: string): () => void {
-  throw new Error(message)
 }

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -234,21 +234,16 @@ export const functions: FunctionBuildersMap = {
       data.length,
 
   keys: () => Object.keys,
-
   values: () => Object.values,
 
-  prod: () => (data: number[]) => data.reduce((a, b) => a * b),
+  prod: () => (data: number[]) => reduce(data, (a, b) => a * b),
+  sum: () => (data: number[]) => reduce(data, (a, b) => a + b),
+  average: () => (data: number[]) => reduce(data, (a, b) => a + b) / data.length,
+  min: () => (data: number[]) => reduce(data, (a, b) => Math.min(a, b)),
+  max: () => (data: number[]) => reduce(data, (a, b) => Math.max(a, b)),
 
-  sum: () => (data: number[]) => data.reduce((a, b) => a + b),
-
-  average: () => (data: number[]) => (functions.sum()(data) as number) / data.length,
-
-  min: () => (data: number[]) => Math.min(...data),
-
-  max: () => (data: number[]) => Math.max(...data),
-
-  and: buildFunction((...args) => args.reduce((a, b) => !!(a && b))),
-  or: buildFunction((...args) => args.reduce((a, b) => !!(a || b))),
+  and: buildFunction((...args: unknown[]) => reduce(args, (a, b) => !!(a && b))),
+  or: buildFunction((...args: unknown[]) => reduce(args, (a, b) => !!(a || b))),
   not: buildFunction((a: unknown) => !a),
 
   exists: (queryGet: JSONQueryFunction) => {
@@ -314,3 +309,19 @@ export const functions: FunctionBuildersMap = {
 }
 
 const truthy = (x: unknown) => x !== null && x !== 0 && x !== false
+
+const reduce = <T>(data: T[], callback: (previousValue: T, currentValue: T) => T): T => {
+  if (!isArray(data)) {
+    throwTypeError('Array expected')
+  }
+
+  if (data.length === 0) {
+    throwTypeError('Non-empty array expected')
+  }
+
+  return data.reduce(callback)
+}
+
+export const throwTypeError = (message: string) => {
+  throw new TypeError(message)
+}

--- a/test-suite/compile.test.json
+++ b/test-suite/compile.test.json
@@ -280,17 +280,17 @@
     },
     {
       "category": "sort",
-      "description": "should throw when sorting nested arrays",
-      "input": [[1], [2], [3]],
+      "description": "should leave content as-is when trying to sort nested arrays",
+      "input": [[3], [1], [2]],
       "query": ["sort"],
-      "throws": "Two numbers or two strings expected"
+      "output": [[3], [1], [2]]
     },
     {
       "category": "sort",
-      "description": "should throw when sorting nested objects",
+      "description": "should leave content as-is when trying to sort nested objects",
       "input": [{ "a": 1 }, { "c": 3 }, { "b": 2 }],
       "query": ["sort"],
-      "throws": "Two numbers or two strings expected"
+      "output": [{ "a": 1 }, { "c": 3 }, { "b": 2 }]
     },
 
     {
@@ -708,10 +708,10 @@
     },
     {
       "category": "sum",
-      "description": "should throw an error when calculating the sum of an empty array",
+      "description": "should return 0 when calculating the sum of an empty array",
       "input": [],
       "query": ["sum"],
-      "throws": "Non-empty array expected"
+      "output": 0
     },
     {
       "category": "sum",
@@ -730,10 +730,10 @@
     },
     {
       "category": "min",
-      "description": "should throw an error when calculating min on an empty array",
+      "description": "should throw an error when calculating min of an empty array",
       "input": [],
       "query": ["min"],
-      "throws": "Non-empty array expected"
+      "output": null
     },
     {
       "category": "min",
@@ -752,10 +752,10 @@
     },
     {
       "category": "max",
-      "description": "should throw an error when calculating max on an empty array",
+      "description": "should throw an error when calculating max of an empty array",
       "input": [],
       "query": ["max"],
-      "throws": "Non-empty array expected"
+      "output": null
     },
     {
       "category": "max",

--- a/test-suite/compile.test.json
+++ b/test-suite/compile.test.json
@@ -685,6 +685,20 @@
       "query": ["sum"],
       "output": 8.1
     },
+    {
+      "category": "sum",
+      "description": "should throw an error when calculating the sum of an empty array",
+      "input": [],
+      "query": ["sum"],
+      "throws": "Non-empty array expected"
+    },
+    {
+      "category": "sum",
+      "description": "should throw an error when calculating the sum a string",
+      "input": "abc",
+      "query": ["sum"],
+      "throws": "Array expected"
+    },
 
     {
       "category": "min",
@@ -692,6 +706,20 @@
       "input": [3, -4, 1, -7],
       "query": ["min"],
       "output": -7
+    },
+    {
+      "category": "min",
+      "description": "should throw an error when calculating min on an empty array",
+      "input": [],
+      "query": ["min"],
+      "throws": "Non-empty array expected"
+    },
+    {
+      "category": "min",
+      "description": "should throw an error when calculating min on a string",
+      "input": "abc",
+      "query": ["min"],
+      "throws": "Array expected"
     },
 
     {
@@ -701,6 +729,20 @@
       "query": ["max"],
       "output": 3
     },
+    {
+      "category": "max",
+      "description": "should throw an error when calculating max on an empty array",
+      "input": [],
+      "query": ["max"],
+      "throws": "Non-empty array expected"
+    },
+    {
+      "category": "max",
+      "description": "should throw an error when calculating max on a string",
+      "input": "abc",
+      "query": ["max"],
+      "throws": "Array expected"
+    },
 
     {
       "category": "prod",
@@ -708,6 +750,20 @@
       "input": [2, 3, 5],
       "query": ["prod"],
       "output": 30
+    },
+    {
+      "category": "prod",
+      "description": "should throw an error when calculating the prod of an empty array",
+      "input": [],
+      "query": ["prod"],
+      "throws": "Non-empty array expected"
+    },
+    {
+      "category": "prod",
+      "description": "should throw an error when calculating the prod a string",
+      "input": "abc",
+      "query": ["prod"],
+      "throws": "Array expected"
     },
 
     {
@@ -723,6 +779,20 @@
       "input": [2, 3, 2, 7, 1],
       "query": ["average"],
       "output": 3
+    },
+    {
+      "category": "average",
+      "description": "should throw an error when calculating the average of an empty array",
+      "input": [],
+      "query": ["average"],
+      "throws": "Non-empty array expected"
+    },
+    {
+      "category": "average",
+      "description": "should throw an error when calculating the average a string",
+      "input": "abc",
+      "query": ["average"],
+      "throws": "Array expected"
     },
 
     {
@@ -955,6 +1025,27 @@
       "query": ["and", true, true, false],
       "output": false
     },
+    {
+      "category": "and",
+      "description": "should calculate and with one argument (1)",
+      "input": null,
+      "query": ["and", false],
+      "output": false
+    },
+    {
+      "category": "and",
+      "description": "should calculate and with one argument (2)",
+      "input": null,
+      "query": ["and", true],
+      "output": true
+    },
+    {
+      "category": "and",
+      "description": "should throw when calculating and with no arguments",
+      "input": null,
+      "query": ["and"],
+      "throws": "Non-empty array expected"
+    },
 
     {
       "category": "or",
@@ -1011,6 +1102,27 @@
       "input": null,
       "query": ["or", false, false, true],
       "output": true
+    },
+    {
+      "category": "or",
+      "description": "should calculate or with one argument (1)",
+      "input": null,
+      "query": ["or", false],
+      "output": false
+    },
+    {
+      "category": "or",
+      "description": "should calculate or with one argument (2)",
+      "input": null,
+      "query": ["or", true],
+      "output": true
+    },
+    {
+      "category": "or",
+      "description": "should throw when calculating or with no arguments",
+      "input": null,
+      "query": ["or"],
+      "throws": "Non-empty array expected"
     },
 
     {


### PR DESCRIPTION
See #8

This PR adds test cases for handling empty arrays and non-array input in functions `sum`, `prod`, `min`, `max`, `average`, `and`, and `or`.

Discussion points:

1. `sum` on an empty array: throw or return `0`?
2. `min` on an empty array: throw or return `null`?
3. `max` on an empty array: throw or return `null`?
4. `and` on an empty array: throw, return `true`, or return `false`?
5. `or` on an empty array: throw or return `false`?
6. What to do with sorting data that cannot be sorted? Throw error, or leave it unsorted?

Right now, this PR throws in all cases 1-6.

@lateapexearlyspeed I would love to hear your thoughts on these discussion points 😄.