### PR TITLE
allow unicode properties in unquoted identifiers

### DIFF
--- a/src/regexps.ts
+++ b/src/regexps.ts
@@ -1,5 +1,5 @@
-export const unquotedPropertyRegex = /^[a-zA-Z_$][a-zA-Z\d_$]*$/
-export const startsWithUnquotedPropertyRegex = /^[a-zA-Z_$][a-zA-Z\d_$]*/
+export const unquotedPropertyRegex = /^[\p{L}\p{Nl}_][\p{L}\p{Nl}\p{Nd}\p{Mn}\p{Mc}\p{Pc}_$]*$/u
+export const startsWithUnquotedPropertyRegex = /^[\p{L}\p{Nl}_][\p{L}\p{Nl}\p{Nd}\p{Mn}\p{Mc}\p{Pc}_$]*/u
 export const startsWithStringRegex = /^"(?:[^"\\]|\\.)*"/ // https://stackoverflow.com/a/249937/1262753
 export const startsWithNumberRegex = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/ // https://stackoverflow.com/a/13340826/1262753
 export const startsWithIntRegex = /^(0|[1-9][0-9]*)/


### PR DESCRIPTION
Allow unicode properties for nicer looking expressions like `groupBy(.Région)` when using datasets coming from foreign languages.

The regexp I introduced should be the one used for valid javascript identifiers, the language json "comes from" originally.