### PR TITLE
allow object prop shorthand notation like {.Prop1.Prop2, .Prop3}

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -171,16 +171,23 @@ export function parse(query: string, options?: JSONQueryParseOptions): JSONQuery
           skipWhitespace()
         }
 
-        const key =
-          parseString() ??
-          parseUnquotedString() ??
-          parseInteger() ??
-          throwSyntaxError('Key expected')
+        if (query[i] === ".") {
+          const prop = parseProperty()
+          const key = prop[prop.length - 1]
+          object[key] = prop
+        } else {
+          const key =
+            parseString() ??
+            parseUnquotedString() ??
+            parseInteger() ??
+            throwSyntaxError('Key expected')
 
-        skipWhitespace()
-        eatChar(':')
+          skipWhitespace()
+          eatChar(':')
 
-        object[key] = parseOperator()
+          object[key] = parseOperator()
+        }
+
       }
 
       eatChar('}')


### PR DESCRIPTION
Allow the use of a simplified object syntax `{.prop, .prop1.prop2}` which is equivalent to `{prop: .prop, prop2: .prop1.prop2}`.

Pairs nice with map and unicode properties (in a separate pull request) : `map({ .Région, .Couleur })` instead of `map({ "Région": ."Région", Couleur: .Couleur })`. It allows a selection of subproperties quicker.

This is reminiscent of allowed javascript syntax when an identifier exists : `{ varname }` is instead `{ varname: varname }`.